### PR TITLE
Constantly updating graph/exchange info

### DIFF
--- a/chart_grabber.py
+++ b/chart_grabber.py
@@ -10,7 +10,7 @@ class Thread(threading.Thread):
 
 
 def grab_chart(time_range):
-    sleeping_ranges = {"1d": 15 * 60,       # Updates every 15 minutes
+    sleeping_ranges = {"1d": 5 * 60,       # Updates every 5 minutes
                        "1w": 60 * 60,       # Updates every hour
                        "1m": 4 * 60 * 60,   # Updates every 4 hours
                        "3m": 11 * 60 * 60}  # Updates every 11 hours


### PR DESCRIPTION
Trial implementation of this feature. Only updates the 1 day graph, imo the others aren't that useful, take up space and make it disordered (can't edit images so when it's deleted they all shuffle positions). 
It needs the channel ID to write to in the conf file (PRICE_CHANNEL).

Also changed graph update to 5 minutes - I find you can miss short pumps with 15 minute update time.